### PR TITLE
Check for replicache instance in hook logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,10 @@ export function useSubscribe<R extends ReadonlyJSONValue>(
 ): R {
   const [snapshot, setSnapshot] = useState<R>(def);
   useEffect(() => {
+    if (!rep) {
+      return
+    }
+    
     return rep.subscribe(query, {
       onData: (data: R) => {
         callbacks.push(() => setSnapshot(data));


### PR DESCRIPTION
Hey there

Many thanks for the library, have been using it on a current project and it's working great!

Was wondering if we can add this check to the `useSubscrbe()` hook so there is no error when the `rep: Replicache` instance is not present?

Use case:

I currently have a `<ReplicacheProvider>` component like so

```jsx
export function ReplicacheProvider({ baseUrl = '', children }) {
  const [replicacheInstance, setReplicacheInstance] = React.useState(null)

  React.useEffect(() => {
    const replicache = new Replicache({
      pushURL: `${baseUrl}/api/replicache-push`,
      pullURL: `${baseUrl}/api/replicache-pull`,
      mutators,
    })

    replicacheListener(replicache)
    setReplicacheInstance(replicache)
  }, [baseUrl])

  return (
    <ReplicacheContext.Provider value={replicacheInstance}>
      {children}
    </ReplicacheContext.Provider>
  )
}
```

However on first render `replicacheInstance` instance is `null` meaning the `useSubscribe()` hook fails inside my components.

In a couple of examples I've seen the suggestion to do something like

```jsx
{rep && <Component />}
```

However this means you see an empty state briefly

To avoid that, I've had to put the hook in a renderless component to get around the "conditional hooks" problem in React

```jsx
const replicache = useReplicache()

return (
  <>
    {replicache && <UseSubscribe />}
  </>
)
```

I feel it's a better API if the hook itself can handle this case without needing extra conditional logic