### PR TITLE
feat: Update useSubscribe to accept Replicache or Pick<Replicache, 'subscribe'> so it can accept ReflectClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,11 @@
         "react": ">=16.0 <18.0",
         "react-dom": ">=16.0 <18.0",
         "replicache": ">=4.0.1 <10.0 || >7.0.0-beta <7.0.0 || >8.0.0-beta <8.0.0 || >9.0.0-beta <9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "replicache": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "react-dom": ">=16.0 <18.0",
     "replicache": ">=4.0.1 <10.0 || >7.0.0-beta <7.0.0 || >8.0.0-beta <8.0.0 || >9.0.0-beta <9.0.0"
   },
+  "peerDependenciesMeta": {
+    "replicache": {
+      "optional": true
+    }
+  }
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",
     "@snowpack/web-test-runner-plugin": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "replicache": {
       "optional": true
     }
-  }
+  },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",
     "@snowpack/web-test-runner-plugin": "^0.2.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ function doCallback() {
 export type Subscribeable = Pick<Replicache, 'subscribe'>;
 
 export function useSubscribe<R extends ReadonlyJSONValue>(
-  rep: Replicache | Subscribeable | null | undefined,
+  subscribeable: Subscribeable | null | undefined,
   query: (tx: ReadTransaction) => Promise<R>,
   def: R,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -31,11 +31,11 @@ export function useSubscribe<R extends ReadonlyJSONValue>(
 ): R {
   const [snapshot, setSnapshot] = useState<R>(def);
   useEffect(() => {
-    if (!rep) {
+    if (!subscribeable) {
       return;
     }
 
-    return rep.subscribe(query, {
+    return subscribeable.subscribe(query, {
       onData: (data: R) => {
         callbacks.push(() => setSnapshot(data));
         if (!hasPendingCallback) {
@@ -44,6 +44,6 @@ export function useSubscribe<R extends ReadonlyJSONValue>(
         }
       },
     });
-  }, [rep, ...deps]);
+  }, [subscribeable, ...deps]);
   return snapshot;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,10 @@ function doCallback() {
   });
 }
 
+export type Subscribeable = Pick<Replicache, 'subscribe'>;
+
 export function useSubscribe<R extends ReadonlyJSONValue>(
-  rep: Replicache | null | undefined,
+  rep: Replicache | null | undefined | Subscribeable,
   query: (tx: ReadTransaction) => Promise<R>,
   def: R,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ function doCallback() {
 export type Subscribeable = Pick<Replicache, 'subscribe'>;
 
 export function useSubscribe<R extends ReadonlyJSONValue>(
-  rep: Replicache | null | undefined | Subscribeable,
+  rep: Replicache | Subscribeable | null | undefined,
   query: (tx: ReadTransaction) => Promise<R>,
   def: R,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Also makes the `"replicache"` peer dependency optional (using peerDependenciesMeta) so npm doesn't automatically install `"replicache"` when `"replicache-react"` is intalled.  