### PR TITLE
fix: fix failing unittest by using setTimeout instead of requestAnimationFrame to wait for render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "replicache-react",
       "version": "2.5.0",
       "license": "ISC",
       "devDependencies": {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -38,17 +38,13 @@ test('null/undefined replicache', async () => {
     },
   });
 
-  // Replicache initializes its client ID on first run, this maakes the subscribe inside
-  // <A> take non-deterministic time. Running an empty mutation here and waiting forces
-  // that work to be done already by the time we get to rendering <A> below.
-  await rep.mutate.dummy();
+  // Replicache initializes its client ID on first run, this makes the
+  // subscribe inside <A> take non-deterministic time.
+  await rep.clientID;
 
   render(<A key="c" rep={rep} def="c" />, div);
   expect(div.textContent).to.equal('c');
-  // TODO: I'm not sure why just a microtask isn't sufficient.
-  await new Promise(res => {
-    window.requestAnimationFrame(res);
-  });
+  await sleep(1);
   expect(div.textContent).to.equal('hello');
 });
 


### PR DESCRIPTION
Using requestAnimationFrame to wait for the subscribe to fire and react render to complete was no longer working in latest chrome. 

Use a setTimeout of 1 instead, which was already what the 'Batching of subscriptions' test was doing.