### PR TITLE
Switch from relying directly on Replicache to an interface.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,19 +23,13 @@
         "prettier": "^2.4.1",
         "react": ">=16.0 <18.0",
         "react-dom": ">=16.0 <18.0",
-        "replicache": ">= 10.0.0",
+        "replicache": "10.0.0",
         "snowpack": "^3.8.8",
         "typescript": "^4.4.3"
       },
       "peerDependencies": {
         "react": ">=16.0 <19.0",
-        "react-dom": ">=16.0 <19.0",
-        "replicache": ">=4.0.1 <12.0 || >7.0.0-beta <7.0.0 || >8.0.0-beta <8.0.0 || >9.0.0-beta <9.0.0 || >10.0.0-alpha <10.0.0 || >10.0.0-beta <10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "replicache": {
-          "optional": true
-        }
+        "react-dom": ">=16.0 <19.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "https://replicache.dev",
   "repository": "github:rocicorp/replicache-react",
   "main": "out/index.js",
+  "module": "out/index.mjs",
   "scripts": {
     "format": "prettier --write 'src/*.{js,jsx,json,ts,tsx,html,css,md}' '*.{cjs,js,jsx,json,ts,tsx,html,css,md}'",
     "check-format": "prettier --check 'src/*.{js,jsx,json,ts,tsx,html,css,md}' '*.{cjs,js,jsx,json,ts,tsx,html,css,md}'",
@@ -19,13 +20,7 @@
   "license": "ISC",
   "peerDependencies": {
     "react": ">=16.0 <19.0",
-    "react-dom": ">=16.0 <19.0",
-    "replicache": ">=4.0.1 <12.0 || >7.0.0-beta <7.0.0 || >8.0.0-beta <8.0.0 || >9.0.0-beta <9.0.0 || >10.0.0-alpha <10.0.0 || >10.0.0-beta <10.0.0"
-  },
-  "peerDependenciesMeta": {
-    "replicache": {
-      "optional": true
-    }
+    "react-dom": ">=16.0 <19.0"
   },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",
@@ -42,7 +37,7 @@
     "prettier": "^2.4.1",
     "react": ">=16.0 <18.0",
     "react-dom": ">=16.0 <18.0",
-    "replicache": ">= 10.0.0",
+    "replicache": "10.0.0",
     "snowpack": "^3.8.8",
     "typescript": "^4.4.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import type {ReadonlyJSONValue, ReadTransaction} from 'replicache';
 import {useEffect, useState} from 'react';
 import {unstable_batchedUpdates} from 'react-dom';
 
+type Subscribable = Pick<Replicache, 'subscribe'>;
+
 // We wrap all the callbacks in a `unstable_batchedUpdates` call to ensure that
 // we do not render things more than once over all of the changed subscriptions.
 
@@ -21,7 +23,7 @@ function doCallback() {
 }
 
 export function useSubscribe<R extends ReadonlyJSONValue>(
-  rep: Replicache | null | undefined,
+  rep: Subscribable | null | undefined,
   query: (tx: ReadTransaction) => Promise<R>,
   def: R,
   deps: Array<unknown> = [],


### PR DESCRIPTION
This makes it easier to use with Reflect.