### PR TITLE
feat: Support more strongly-typed ReadTransaction.

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -75,9 +75,10 @@ test('Batching of subscriptions', async () => {
   function A({rep}: {rep: MyRep}) {
     const dataA = useSubscribe(
       rep,
-      async tx => (await tx.get('a')) ?? null,
+      // TODO: Use type param to get when new Replicache is released.
+      async tx => ((await tx.get('a')) as string | undefined) ?? null,
       null,
-    ) as string | null;
+    );
     renderLog.push('render A', dataA);
     return <B rep={rep} dataA={dataA} />;
   }
@@ -85,9 +86,9 @@ test('Batching of subscriptions', async () => {
   function B({rep, dataA}: {rep: MyRep; dataA: string | null}) {
     const dataB = useSubscribe(
       rep,
-      async tx => (await tx.get('b')) ?? null,
+      async tx => ((await tx.get('b')) as string | undefined) ?? null,
       null,
-    ) as string | null;
+    );
     renderLog.push('render B', dataA, dataB);
     return (
       <>


### PR DESCRIPTION
# Problem

useSubscribe() is used by both Replicache and Reflect. Reflect has added a new form of ReadTransaction that has a generic get<T> method. We would like users of replicache-react to be able to use that.

However, currently replicache-react pulls in Replicache directly and uses its ReadTransaction. We could publish a new Replicache with the new signature, but then we would have a new problem: that head replicache-react only works with the latest Replicache/Reflect.

# Solution

Decouple replicache-react and Replicache completely by defining an abstract Subscribable.