### PR TITLE
CI: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -16,8 +16,8 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
       - name: Enable Corepack
@@ -29,8 +29,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
       - name: Enable Corepack
@@ -42,8 +42,8 @@ jobs:
     name: Check Types
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
       - name: Enable Corepack
@@ -55,8 +55,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22.x
       - name: Enable Corepack


### PR DESCRIPTION
Pins \`actions/checkout\`, \`actions/setup-node\`, and \`pnpm/action-setup\` to full-length commit SHAs (v6) instead of mutable tags, for supply-chain safety. \`actions/upload-artifact\` was already SHA-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)